### PR TITLE
Add a timeout argument and increase default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+
+## [1.2.0] - 2016-06-03
 ### Added
   - Option to set the timeout. Default to 5000 ms.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+  - Option to set the timeout. Default to 5000 ms.
 
 ## [1.1.0] - 2016-05-05
 ### Added

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ const revFileName = 'rev-manifest.json';
 commander
   .option('-r, --manifest <filename>', 'Manifest file')
   .option('-m, --mv', 'move file instead of copy')
+  .option('-t, --timeout <number>', 'Timeout to wait for data until the process exits', parseInt, 5000)
   .parse(process.argv);
 
 /* Main */
@@ -28,7 +29,7 @@ const timeID = setTimeout(() => {
   process.stdout.write('No data received from stdin!');
   commander.help();
   process.exit(1);
-}, 2000);
+}, commander.timeout);
 
 var dataStdin = '';
 process.stdin.on('data', function(data) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rev-ls",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Revved a list of files outputed by a `ls` or `find`.",
   "bin": {
     "rev-ls": "index.js"


### PR DESCRIPTION
The default timeout to wait for data before exiting is a bit too short.

See also cr0cK/ls-to-cp#1.
